### PR TITLE
security: install Composer in specific channel #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ symfony_composer_path: "{{ ansistrano_deploy_to }}/composer.phar"
 symfony_composer_options: '--no-dev --optimize-autoloader --no-interaction'
 symfony_composer_self_update: true # Always attempt a composer self-update
 symfony_composer_version: 1.10.1 # Install specific composer version. If this variable is not set the latest stable version is installed
+symfony_composer_channel: 2.2 # Install specific composer channel. 
 
 symfony_run_assets_install: true
 symfony_assets_options: '--no-interaction'

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -18,7 +18,7 @@
   when: symfony_composer_version is defined
 
 - name: Install composer installer
-  get_url: url=https://composer.github.io/installer dest={{ansistrano_deploy_to}}/composer-installer.php mode=0755 validate_certs=no force=no
+  get_url: url=https://getcomposer.org/installer dest={{ansistrano_deploy_to}}/composer-installer.php mode=0755 validate_certs=no force=no
   when: symfony_composer_channel is defined
 
 - name: Install composer {{symfony_composer_channel}}

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -11,35 +11,20 @@
 
 - name: Install stable composer
   get_url: url=https://getcomposer.org/composer-stable.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
-  when: symfony_composer_version is not defined
+  when: symfony_composer_version is not defined and symfony_composer_channel is not defined
 
 - name: Install composer {{symfony_composer_version}}
   get_url: url=https://getcomposer.org/download/{{symfony_composer_version}}/composer.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
   when: symfony_composer_version is defined
 
+- name: Install composer installer
+  get_url: url=https://composer.github.io/installer dest={{ansistrano_deploy_to}}/composer-installer.php mode=0755 validate_certs=no force=no
+  when: symfony_composer_channel is defined
+
 - name: Install composer {{symfony_composer_channel}}
-  shell: |
-    #!/bin/sh
-    
-    chdir {{symfony_composer_path}}
-  
-    # https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
-  
-    EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
-    
-    if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
-    then
-    >&2 echo 'ERROR: Invalid installer checksum'
-    rm composer-setup.php
-    exit 1
-    fi
-  
-    php composer-setup.php --quiet --{{symfony_composer_channel}}
-    RESULT=$?
-    rm composer-setup.php
-    exit $RESULT
+  shell:
+    cmd: sh composer-installer.php --quiet --{{symfony_composer_channel}}
+    chdir: {{ansistrano_deploy_to}}
   when: symfony_composer_channel is defined
 
 - name: Run composer install

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -24,7 +24,7 @@
 - name: Install composer {{symfony_composer_channel}}
   shell:
     cmd: sh composer-installer.php --quiet --{{symfony_composer_channel}}
-    chdir: {{ansistrano_deploy_to}}
+    chdir: "{{ansistrano_deploy_to}}"
   when: symfony_composer_channel is defined
 
 - name: Run composer install

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -23,7 +23,7 @@
 
 - name: Install composer {{symfony_composer_channel}}
   shell:
-    cmd: sh composer-installer.php --quiet --{{symfony_composer_channel}}
+    cmd: "{{symfony_php_path}} composer-installer.php --quiet --{{symfony_composer_channel}}"
     chdir: "{{ansistrano_deploy_to}}"
   when: symfony_composer_channel is defined
 

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -17,6 +17,31 @@
   get_url: url=https://getcomposer.org/download/{{symfony_composer_version}}/composer.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
   when: symfony_composer_version is defined
 
+- name: Install composer {{symfony_composer_channel}}
+  shell: |
+    #!/bin/sh
+    
+    chdir {{symfony_composer_path}}
+  
+    # https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+  
+    EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+    
+    if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+    then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+    fi
+  
+    php composer-setup.php --quiet --{{symfony_composer_channel}}
+    RESULT=$?
+    rm composer-setup.php
+    exit $RESULT
+  when: symfony_composer_channel is defined
+
 - name: Run composer install
   shell: chdir={{ansistrano_release_path.stdout}}
     export SYMFONY_ENV={{symfony_env}} APP_ENV={{symfony_env}} && {{symfony_php_path}} {{symfony_composer_path}} install {{symfony_composer_options}}


### PR DESCRIPTION
Install with a release version, using symfony_composer_version: 2.2 doesn't accept 2.2.

Composer setup script supports channel install.

A channel is important to get patched versions.

Like symfony_composer_version, we can opin with symfony_composer_channel